### PR TITLE
fix(api): append tool results to history on early tool execution errors

### DIFF
--- a/pkg/api/agent.go
+++ b/pkg/api/agent.go
@@ -1254,6 +1254,28 @@ type runtimeToolExecutor struct {
 	permissionResolver tool.PermissionResolver
 }
 
+func (t *runtimeToolExecutor) appendToolResult(call agent.ToolCall, content string, blocks []model.ContentBlock) {
+	if t.history == nil {
+		return
+	}
+	t.history.Append(message.Message{
+		Role: "tool",
+		ToolCalls: []message.ToolCall{{
+			ID:     call.ID,
+			Name:   call.Name,
+			Result: content,
+		}},
+	})
+	if len(blocks) == 0 {
+		return
+	}
+	t.history.Append(message.Message{
+		Role:          "user",
+		Content:       fmt.Sprintf("[multimodal content from tool: %s]", call.Name),
+		ContentBlocks: convertAPIContentBlocks(blocks),
+	})
+}
+
 func (t *runtimeToolExecutor) measureUsage() sandbox.ResourceUsage {
 	var stats runtime.MemStats
 	runtime.ReadMemStats(&stats)
@@ -1286,10 +1308,14 @@ func (t *runtimeToolExecutor) isAllowed(ctx context.Context, name string) bool {
 
 func (t *runtimeToolExecutor) Execute(ctx context.Context, call agent.ToolCall, _ *agent.Context) (agent.ToolResult, error) {
 	if t.executor == nil {
-		return agent.ToolResult{}, errors.New("tool executor not initialised")
+		err := errors.New("tool executor not initialised")
+		t.appendToolResult(call, fmt.Sprintf(`{"error":%q}`, err.Error()), nil)
+		return agent.ToolResult{}, err
 	}
 	if !t.isAllowed(ctx, call.Name) {
-		return agent.ToolResult{}, fmt.Errorf("tool %s is not whitelisted", call.Name)
+		err := fmt.Errorf("tool %s is not whitelisted", call.Name)
+		t.appendToolResult(call, fmt.Sprintf(`{"error":%q}`, err.Error()), nil)
+		return agent.ToolResult{}, err
 	}
 
 	// Defensive check: if tool call has empty/nil arguments but the tool requires
@@ -1304,43 +1330,13 @@ func (t *runtimeToolExecutor) Execute(ctx context.Context, call agent.ToolCall, 
 							"the API proxy likely stripped tool_use.input — check proxy configuration",
 						call.Name, schema.Required)
 					log.Printf("WARNING: %s (id=%s)", errMsg, call.ID)
-					if t.history != nil {
-						t.history.Append(message.Message{
-							Role: "tool",
-							ToolCalls: []message.ToolCall{{
-								ID:     call.ID,
-								Name:   call.Name,
-								Result: errMsg,
-							}},
-						})
-					}
+					t.appendToolResult(call, errMsg, nil)
 					return agent.ToolResult{
 						Name:     call.Name,
 						Output:   errMsg,
 						Metadata: map[string]any{"error": "empty_arguments"},
 					}, nil
 				}
-			}
-		}
-	}
-
-	// Helper to append tool result to history.
-	appendToolResult := func(content string, blocks []model.ContentBlock) {
-		if t.history != nil {
-			t.history.Append(message.Message{
-				Role: "tool",
-				ToolCalls: []message.ToolCall{{
-					ID:     call.ID,
-					Name:   call.Name,
-					Result: content,
-				}},
-			})
-			if len(blocks) > 0 {
-				t.history.Append(message.Message{
-					Role:          "user",
-					Content:       fmt.Sprintf("[multimodal content from tool: %s]", call.Name),
-					ContentBlocks: convertAPIContentBlocks(blocks),
-				})
 			}
 		}
 	}
@@ -1378,7 +1374,7 @@ func (t *runtimeToolExecutor) Execute(ctx context.Context, call agent.ToolCall, 
 	if preErr != nil {
 		// Hook denied execution - still need to add tool_result to history
 		errContent := fmt.Sprintf(`{"error":%q}`, preErr.Error())
-		appendToolResult(errContent, nil)
+		t.appendToolResult(call, errContent, nil)
 		return agent.ToolResult{Name: call.Name, Output: errContent, Metadata: map[string]any{"error": preErr.Error()}}, preErr
 	}
 	if params != nil {
@@ -1439,11 +1435,11 @@ func (t *runtimeToolExecutor) Execute(ctx context.Context, call agent.ToolCall, 
 
 	if hookErr := t.hooks.PostToolUse(ctx, coreToolResultPayload(call, result, err)); hookErr != nil && err == nil {
 		// Hook failed - still need to add tool_result to history
-		appendToolResult(content, blocks)
+		t.appendToolResult(call, content, blocks)
 		return toolResult, hookErr
 	}
 
-	appendToolResult(content, blocks)
+	t.appendToolResult(call, content, blocks)
 	return toolResult, err
 }
 

--- a/pkg/api/agent_additional_test.go
+++ b/pkg/api/agent_additional_test.go
@@ -376,6 +376,96 @@ func TestRuntimeToolExecutorEnforcesResourceLimits(t *testing.T) {
 	}
 }
 
+func TestRuntimeToolExecutorWhitelistRejectionAppendsHistory(t *testing.T) {
+	hist := message.NewHistory()
+	hist.Append(message.Message{
+		Role: "assistant",
+		ToolCalls: []message.ToolCall{{
+			ID:   "call_1",
+			Name: "echo",
+		}},
+	})
+
+	rtExec := &runtimeToolExecutor{
+		executor:  tool.NewExecutor(tool.NewRegistry(), nil),
+		hooks:     &runtimeHookAdapter{},
+		history:   hist,
+		allow:     map[string]struct{}{"other": {}},
+		sessionID: "s1",
+	}
+
+	_, err := rtExec.Execute(context.Background(), agent.ToolCall{
+		ID:    "call_1",
+		Name:  "echo",
+		Input: map[string]any{"text": "hi"},
+	}, agent.NewContext())
+	if err == nil {
+		t.Fatal("expected whitelist rejection")
+	}
+
+	msgs := hist.All()
+	if len(msgs) != 2 {
+		t.Fatalf("expected 2 history messages, got %d", len(msgs))
+	}
+	last := msgs[len(msgs)-1]
+	if last.Role != "tool" {
+		t.Fatalf("expected tool message, got role %q", last.Role)
+	}
+	if len(last.ToolCalls) != 1 {
+		t.Fatalf("expected 1 tool call result, got %d", len(last.ToolCalls))
+	}
+	if last.ToolCalls[0].ID != "call_1" {
+		t.Fatalf("expected tool call id call_1, got %q", last.ToolCalls[0].ID)
+	}
+	if !strings.Contains(last.ToolCalls[0].Result, "not whitelisted") {
+		t.Fatalf("expected whitelist error in result, got %q", last.ToolCalls[0].Result)
+	}
+}
+
+func TestRuntimeToolExecutorNilExecutorAppendsHistory(t *testing.T) {
+	hist := message.NewHistory()
+	hist.Append(message.Message{
+		Role: "assistant",
+		ToolCalls: []message.ToolCall{{
+			ID:   "call_2",
+			Name: "echo",
+		}},
+	})
+
+	rtExec := &runtimeToolExecutor{
+		hooks:     &runtimeHookAdapter{},
+		history:   hist,
+		sessionID: "s2",
+	}
+
+	_, err := rtExec.Execute(context.Background(), agent.ToolCall{
+		ID:    "call_2",
+		Name:  "echo",
+		Input: map[string]any{"text": "hi"},
+	}, agent.NewContext())
+	if err == nil {
+		t.Fatal("expected nil executor error")
+	}
+
+	msgs := hist.All()
+	if len(msgs) != 2 {
+		t.Fatalf("expected 2 history messages, got %d", len(msgs))
+	}
+	last := msgs[len(msgs)-1]
+	if last.Role != "tool" {
+		t.Fatalf("expected tool message, got role %q", last.Role)
+	}
+	if len(last.ToolCalls) != 1 {
+		t.Fatalf("expected 1 tool call result, got %d", len(last.ToolCalls))
+	}
+	if last.ToolCalls[0].ID != "call_2" {
+		t.Fatalf("expected tool call id call_2, got %q", last.ToolCalls[0].ID)
+	}
+	if !strings.Contains(last.ToolCalls[0].Result, "not initialised") {
+		t.Fatalf("expected executor error in result, got %q", last.ToolCalls[0].Result)
+	}
+}
+
 func TestAvailableToolsNilRegistry(t *testing.T) {
 	if defs := availableTools(nil, nil); defs != nil {
 		t.Fatalf("expected nil definitions, got %+v", defs)


### PR DESCRIPTION

  ## Summary

  Fix missing tool result history entries when `runtimeToolExecutor` returns early.

  Two early-return paths were skipping the tool result append:

  - executor not initialized
  - tool rejected by whitelist

  This could leave a tool call without a matching tool result in conversation history.

  ## Changes

  - added a small `appendToolResult` helper on `runtimeToolExecutor`
  - reused it in the two affected early-return branches
  - kept the existing append flow aligned with the same helper

  ## Tests

  Added regression tests for:

  - whitelist rejection appends history
  - nil executor appends history

  ## Verification

  ```bash
  go test ./pkg/api -run 'TestRuntimeToolExecutor(WhitelistRejectionAppendsHistory|
  NilExecutorAppendsHistory)$'
  go test ./pkg/api