### PR TITLE
fix(api): keep unknown prompt skill markers as text

### DIFF
--- a/pkg/api/agent.go
+++ b/pkg/api/agent.go
@@ -514,10 +514,7 @@ func (rt *Runtime) prepare(ctx context.Context, req Request) (preparedRun, error
 			return ok
 		}
 	}
-	parsedSkills, cleanedPrompt, missingSkills := extractPromptSkillInvocations(normalized.Prompt, skillExists, commandExists)
-	if err := unknownForcedSkillsError(missingSkills); err != nil {
-		return preparedRun{}, err
-	}
+	parsedSkills, cleanedPrompt := extractPromptSkillInvocations(normalized.Prompt, skillExists, commandExists)
 	normalized.ForceSkills = mergeOrderedNames(normalized.ForceSkills, parsedSkills)
 	normalized.Prompt = cleanedPrompt
 	prompt := strings.TrimSpace(normalized.Prompt)

--- a/pkg/api/request_helpers.go
+++ b/pkg/api/request_helpers.go
@@ -32,14 +32,12 @@ func removeCommandLines(prompt string, invs []commands.Invocation) string {
 	return strings.TrimSpace(strings.Join(kept, "\n"))
 }
 
-func extractPromptSkillInvocations(prompt string, skillExists func(string) bool, commandExists func(string) bool) ([]string, string, []string) {
+func extractPromptSkillInvocations(prompt string, skillExists func(string) bool, commandExists func(string) bool) ([]string, string) {
 	if strings.TrimSpace(prompt) == "" {
-		return nil, prompt, nil
+		return nil, prompt
 	}
 	var forced []string
-	var missing []string
 	forcedSeen := map[string]struct{}{}
-	missingSeen := map[string]struct{}{}
 	lines := strings.Split(prompt, "\n")
 	cleanedLines := make([]string, 0, len(lines))
 	for _, line := range lines {
@@ -66,14 +64,11 @@ func extractPromptSkillInvocations(prompt string, skillExists func(string) bool,
 				}
 				continue
 			}
-			if _, seen := missingSeen[name]; !seen {
-				missingSeen[name] = struct{}{}
-				missing = append(missing, name)
-			}
+			kept = append(kept, field)
 		}
 		cleanedLines = append(cleanedLines, strings.Join(kept, " "))
 	}
-	return forced, strings.TrimSpace(strings.Join(cleanedLines, "\n")), missing
+	return forced, strings.TrimSpace(strings.Join(cleanedLines, "\n"))
 }
 
 func parsePromptSkillMarker(token string) (string, bool) {
@@ -91,17 +86,6 @@ func parsePromptSkillMarker(token string) (string, bool) {
 		return "", false
 	}
 	return name, true
-}
-
-func unknownForcedSkillsError(names []string) error {
-	switch len(names) {
-	case 0:
-		return nil
-	case 1:
-		return fmt.Errorf("api: unknown skill %q", names[0])
-	default:
-		return fmt.Errorf("api: unknown skills %s", strings.Join(names, ", "))
-	}
 }
 
 func applyPromptMetadata(prompt string, meta map[string]any) string {

--- a/pkg/api/request_helpers_additional_test.go
+++ b/pkg/api/request_helpers_additional_test.go
@@ -203,7 +203,7 @@ func TestExtractPromptSkillInvocations(t *testing.T) {
 		return name == "tag"
 	}
 
-	forced, cleaned, missing := extractPromptSkillInvocations(
+	forced, cleaned := extractPromptSkillInvocations(
 		"/tag keep\n$ai-sdk /yt-dlp build this\n$ai-sdk",
 		skillLookup,
 		commandLookup,
@@ -215,16 +215,13 @@ func TestExtractPromptSkillInvocations(t *testing.T) {
 	if got := cleaned; got != "/tag keep\nbuild this" {
 		t.Fatalf("unexpected cleaned prompt %q", got)
 	}
-	if len(missing) != 0 {
-		t.Fatalf("unexpected missing skills: %v", missing)
-	}
 }
 
-func TestExtractPromptSkillInvocationsTreatsUnknownSlashAsSkill(t *testing.T) {
+func TestExtractPromptSkillInvocationsKeepsUnknownTokens(t *testing.T) {
 	t.Parallel()
 
-	forced, cleaned, missing := extractPromptSkillInvocations(
-		"/unknown-skill inspect system",
+	forced, cleaned := extractPromptSkillInvocations(
+		"/unknown-skill inspect system\n$jobId template variable",
 		func(string) bool { return false },
 		func(string) bool { return false },
 	)
@@ -232,10 +229,7 @@ func TestExtractPromptSkillInvocationsTreatsUnknownSlashAsSkill(t *testing.T) {
 	if len(forced) != 0 {
 		t.Fatalf("expected no resolved skills, got %v", forced)
 	}
-	if got := cleaned; got != "inspect system" {
+	if got := cleaned; got != "/unknown-skill inspect system\n$jobId template variable" {
 		t.Fatalf("unexpected cleaned prompt %q", got)
-	}
-	if len(missing) != 1 || missing[0] != "unknown-skill" {
-		t.Fatalf("unexpected missing skills: %v", missing)
 	}
 }

--- a/pkg/api/skills_pipeline_test.go
+++ b/pkg/api/skills_pipeline_test.go
@@ -49,3 +49,48 @@ func TestExecuteSkillsDedupesAutoAndForcedMatches(t *testing.T) {
 		t.Fatalf("unexpected skill result %+v", resp.SkillResults[0])
 	}
 }
+
+func TestRunKeepsUnknownPromptSkillMarkersAsPlainText(t *testing.T) {
+	root := newClaudeProject(t)
+	mdl := &stubModel{responses: []*model.Response{{Message: model.Message{Role: "assistant", Content: "ok"}}}}
+
+	var activation skills.ActivationContext
+	rt, err := New(context.Background(), Options{
+		ProjectRoot: root,
+		Model:       mdl,
+		Skills: []SkillRegistration{{
+			Definition: skills.Definition{Name: "mpp-pipeline-orchestrator"},
+			Handler: skills.HandlerFunc(func(_ context.Context, ac skills.ActivationContext) (skills.Result, error) {
+				activation = ac
+				return skills.Result{}, nil
+			}),
+		}},
+	})
+	if err != nil {
+		t.Fatalf("runtime: %v", err)
+	}
+	t.Cleanup(func() { _ = rt.Close() })
+
+	resp, err := rt.Run(context.Background(), Request{
+		Prompt: "$mpp-pipeline-orchestrator\n处理该任务。中间结果放在 $jobId 目录。",
+	})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if len(resp.SkillResults) != 1 {
+		t.Fatalf("expected one skill result, got %d", len(resp.SkillResults))
+	}
+	if got := activation.Prompt; got != "处理该任务。中间结果放在 $jobId 目录。" {
+		t.Fatalf("unexpected skill activation prompt %q", got)
+	}
+	if len(mdl.requests) == 0 {
+		t.Fatal("expected model request")
+	}
+	last := mdl.requests[len(mdl.requests)-1]
+	if len(last.Messages) == 0 {
+		t.Fatal("expected model messages")
+	}
+	if got := last.Messages[len(last.Messages)-1].TextContent(); got != "处理该任务。中间结果放在 $jobId 目录。" {
+		t.Fatalf("unexpected model prompt %q", got)
+	}
+}


### PR DESCRIPTION
 ## Summary

  Fix prompt skill marker parsing so unknown `$token` or `/token` values are preserved as plain prompt text instead of causing a fatal `unknown skill` error.

  This resolves cases like `$jobId` in normal prompt content being misinterpreted as a forced skill reference.

  Closes #4

  ## Changes

  - update `extractPromptSkillInvocations` to return only resolved forced skills plus cleaned prompt text
  - preserve unknown prompt markers in the cleaned prompt instead of collecting them as missing skills
  - remove the `unknownForcedSkillsError` path from runtime prepare flow
  - update helper tests to assert unknown markers are kept in prompt text
  - add a runtime regression test covering a valid forced skill plus an unrelated `$jobId` placeholder in prompt content

  ## Why

  The previous behavior scanned the full prompt and treated any valid-looking `$token` or `/token` as a skill reference. If that token was not registered, the request failed
  before normal execution.

  That was too aggressive for real prompt text containing variables, shell-like placeholders, or template syntax.

  This change keeps the existing lightweight parsing model while avoiding false positives.

  ## Testing

  ```bash
  go test ./pkg/api -count=1

  Passed.

  Note: go test ./... still hits an unrelated existing failure in pkg/tool/builtin:

  TestImageReadToolReadsPNG
  execute image_read: security: resolve failed: security: symlink rejected /var